### PR TITLE
Validate the flag and print out usage

### DIFF
--- a/piper/main.go
+++ b/piper/main.go
@@ -21,6 +21,21 @@ func main() {
 
 	flag.Parse()
 
+	var errors []string
+	if len(taskFilePath) == 0 {
+		errors = append(errors, fmt.Sprintf(" -c is a required flag"))
+	}
+
+	if len(errors) > 0 {
+		fmt.Fprintln(os.Stderr, "Errors:")
+		for _, err := range errors {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		fmt.Fprintln(os.Stderr, "\nUsage:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
 	taskConfig, err := piper.Parser{}.Parse(taskFilePath)
 	if err != nil {
 		log.Fatalln(err)

--- a/piper/main_test.go
+++ b/piper/main_test.go
@@ -42,6 +42,17 @@ var _ = Describe("Piper", func() {
 	})
 
 	Context("failure cases", func() {
+		Context("when the flag is not passed in", func() {
+			It("Print an error and exit with status 1", func() {
+				command := exec.Command(pathToPiper)
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Err.Contents()).To(ContainSubstring("-c is a required flag"))
+			})
+		})
+
 		Context("when the task file does not exist", func() {
 			It("prints an error and exits 1", func() {
 				command := exec.Command(pathToPiper, "-c", "no-such-file")


### PR DESCRIPTION
```
$ go run piper/main.go
Errors:
 -c is a required flag

Usage:
  -c string
        path to the task configuration file
  -i value
        <input-name>=<input-location> (default [])
exit status 1
```
