### PR TITLE
Allow '=' to be part of the value of an ENV var

### DIFF
--- a/env_var_builder.go
+++ b/env_var_builder.go
@@ -7,7 +7,7 @@ type EnvVarBuilder struct{}
 func (b EnvVarBuilder) Build(environment []string, params map[string]string) []DockerEnv {
 	env := make(map[string]string)
 	for _, variable := range environment {
-		parts := strings.Split(variable, "=")
+		parts := strings.SplitN(variable, "=", 2)
 		env[parts[0]] = parts[1]
 	}
 

--- a/env_var_builder_test.go
+++ b/env_var_builder_test.go
@@ -28,4 +28,20 @@ var _ = Describe("EnvVarBuilder", func() {
 		}))
 
 	})
+
+	Context("when env vars have '=' signs in the value", func() {
+		It("returns a list of environment variables with '=' signs still in their place", func() {
+			vars := piper.EnvVarBuilder{}.Build([]string{
+				"VAR1=var-1==42=",
+			}, map[string]string{
+				"VAR1": "meow",
+			})
+			Expect(vars).To(ConsistOf([]piper.DockerEnv{
+				{
+					Key:   "VAR1",
+					Value: "var-1==42=",
+				},
+			}))
+		})
+	})
 })


### PR DESCRIPTION
- This is needed for what we are working on because some of our ENV vars
  contains base64 encoded strings that potentially have '=' signs at the
  end for padding.
- A more concrete example of this would be a private key. Without the
  ----END PRIVATE KEY----- footer, openssl thinks that this key is
  password protected. base64 encoding padding often shows up in keys.
