### PR TITLE
Making sure that piper works with the latest docker client

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -12,7 +12,7 @@ type DockerVolumeMount struct {
 }
 
 func (m DockerVolumeMount) String() string {
-	return fmt.Sprintf("--volume=\"%s:%s\"", m.LocalPath, m.RemotePath)
+	return fmt.Sprintf("--volume=%s:%s", m.LocalPath, m.RemotePath)
 }
 
 type DockerEnv struct {
@@ -21,7 +21,7 @@ type DockerEnv struct {
 }
 
 func (e DockerEnv) String() string {
-	return fmt.Sprintf("--env=\"%s=%s\"", e.Key, e.Value)
+	return fmt.Sprintf("--env=%s=%s", e.Key, e.Value)
 }
 
 type DockerClient struct {
@@ -46,7 +46,7 @@ func (c DockerClient) Pull(image string) error {
 func (c DockerClient) Run(command, image string, envVars []DockerEnv, mounts []DockerVolumeMount) error {
 	args := []string{
 		"run",
-		fmt.Sprintf("--workdir=%q", VolumeMountPoint),
+		fmt.Sprintf("--workdir=%s", VolumeMountPoint),
 	}
 
 	for _, envVar := range envVars {

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -74,11 +74,11 @@ var _ = Describe("DockerClient", func() {
 
 			args := []string{
 				"run",
-				"--workdir=\"/tmp/build\"",
-				"--env=\"VAR1=var-1\"",
-				"--env=\"VAR2=var-2\"",
-				"--volume=\"/some/local/path-1:/some/remote/path-1\"",
-				"--volume=\"/some/local/path-2:/some/remote/path-2\"",
+				"--workdir=/tmp/build",
+				"--env=VAR1=var-1",
+				"--env=VAR2=var-2",
+				"--volume=/some/local/path-1:/some/remote/path-1",
+				"--volume=/some/local/path-2:/some/remote/path-2",
 				"my-image",
 				"my-task.sh",
 			}

--- a/piper/main_test.go
+++ b/piper/main_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(dockerInvocations)), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image", pathToDocker),
-			fmt.Sprintf("%s run --workdir=\"/tmp/build\" --env=\"VAR1=var-1\" --volume=\"/tmp/local-1:/tmp/build/input-1\" --volume=\"/tmp/local-2:/tmp/build/output-1\" my-image my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --env=VAR1=var-1 --volume=/tmp/local-1:/tmp/build/input-1 --volume=/tmp/local-2:/tmp/build/output-1 my-image my-task.sh", pathToDocker),
 		}))
 	})
 
@@ -60,7 +60,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(dockerInvocations)), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image:x.y", pathToDocker),
-			fmt.Sprintf("%s run --workdir=\"/tmp/build\" --volume=\"/tmp/local-1:/tmp/build/some/path/input\" --volume=\"/tmp/local-2:/tmp/build/some/path/output\" my-image:x.y my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --volume=/tmp/local-1:/tmp/build/some/path/input --volume=/tmp/local-2:/tmp/build/some/path/output my-image:x.y my-task.sh", pathToDocker),
 		}))
 	})
 


### PR DESCRIPTION
Somehow `piper` fails when used against the latest `docker` which is no longer in beta.

This fix seems to work.
