### PR TITLE
adding `args` from a `task` config and `caches`

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -51,7 +51,15 @@ func (c DockerClient) Pull(image string, dryRun bool) error {
 	return nil
 }
 
-func (c DockerClient) Run(command []string, image string, envVars []DockerEnv, mounts []DockerVolumeMount, privileged bool, dryRun bool, rm bool) error {
+func (c DockerClient) Run(
+	command []string,
+	image string,
+	envVars []DockerEnv,
+	mounts []DockerVolumeMount,
+	privileged bool,
+	dryRun bool,
+	rm bool,
+) error {
 	c.Command.Args = append(c.Command.Args, "run", fmt.Sprintf("--workdir=%s", VolumeMountPoint))
 
 	if privileged {

--- a/docker_client.go
+++ b/docker_client.go
@@ -51,7 +51,7 @@ func (c DockerClient) Pull(image string, dryRun bool) error {
 	return nil
 }
 
-func (c DockerClient) Run(command, image string, envVars []DockerEnv, mounts []DockerVolumeMount, privileged bool, dryRun bool, rm bool) error {
+func (c DockerClient) Run(command []string, image string, envVars []DockerEnv, mounts []DockerVolumeMount, privileged bool, dryRun bool, rm bool) error {
 	c.Command.Args = append(c.Command.Args, "run", fmt.Sprintf("--workdir=%s", VolumeMountPoint))
 
 	if privileged {
@@ -70,7 +70,8 @@ func (c DockerClient) Run(command, image string, envVars []DockerEnv, mounts []D
 		c.Command.Args = append(c.Command.Args, mount.String())
 	}
 
-	c.Command.Args = append(c.Command.Args, image, command)
+	c.Command.Args = append(c.Command.Args, image)
+	c.Command.Args = append(c.Command.Args, command...)
 
 	if dryRun {
 		fmt.Fprintln(c.Stdout, strings.Join(c.Command.Args, " "))

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -58,7 +58,7 @@ var _ = Describe("DockerClient", func() {
 
 	Describe("Run", func() {
 		It("runs the command with the given volume mounts, and environment", func() {
-			err := client.Run("my-task.sh", "my-image", []piper.DockerEnv{
+			err := client.Run([]string{"my-task.sh", "-my-arg1", "-my-arg2"}, "my-image", []piper.DockerEnv{
 				{
 					Key:   "VAR1",
 					Value: "var-1",
@@ -88,13 +88,15 @@ var _ = Describe("DockerClient", func() {
 				"--volume=/some/local/path-2:/some/remote/path-2",
 				"my-image",
 				"my-task.sh",
+				"-my-arg1",
+				"-my-arg2",
 			}
 
 			Expect(stdout.String()).To(Equal(strings.Join(args, " ") + "\n"))
 		})
 
 		It("runs the command in privileged mode", func() {
-			err := client.Run("my-task.sh", "my-image",
+			err := client.Run([]string{"my-task.sh"}, "my-image",
 				[]piper.DockerEnv{},
 				[]piper.DockerVolumeMount{}, true, false, false)
 			Expect(err).NotTo(HaveOccurred())
@@ -111,7 +113,7 @@ var _ = Describe("DockerClient", func() {
 		})
 
 		It("runs the command with --rm argument", func() {
-			err := client.Run("my-task.sh", "my-image",
+			err := client.Run([]string{"my-task.sh"}, "my-image",
 				[]piper.DockerEnv{},
 				[]piper.DockerVolumeMount{}, false, false, true)
 			Expect(err).NotTo(HaveOccurred())
@@ -128,7 +130,7 @@ var _ = Describe("DockerClient", func() {
 		})
 
 		It("prints the docker command without running it", func() {
-			err := client.Run("my-task.sh", "my-image",
+			err := client.Run([]string{"my-task.sh"}, "my-image",
 				[]piper.DockerEnv{},
 				[]piper.DockerVolumeMount{}, true, true, false)
 			Expect(err).NotTo(HaveOccurred())
@@ -152,7 +154,7 @@ var _ = Describe("DockerClient", func() {
 						Command: exec.Command("no-such-executable"),
 						Stdout:  stdout,
 					}
-					err := client.Run("some-command", "some-image", []piper.DockerEnv{}, []piper.DockerVolumeMount{}, false, false, false)
+					err := client.Run([]string{"some-command"}, "some-image", []piper.DockerEnv{}, []piper.DockerVolumeMount{}, false, false, false)
 					Expect(err).To(MatchError(ContainSubstring("executable file not found in $PATH")))
 				})
 			})

--- a/parser.go
+++ b/parser.go
@@ -16,7 +16,7 @@ type VolumeMount struct {
 
 type Run struct {
 	Path string   `yaml:"path"`
-	args []string `yaml:"args"`
+	Args []string `yaml:"args"`
 	dir  string   `yaml:"dir"`
 }
 

--- a/parser.go
+++ b/parser.go
@@ -41,6 +41,7 @@ type Task struct {
 	Run           Run
 	Inputs        []VolumeMount
 	Outputs       []VolumeMount
+	Caches        []VolumeMount
 	Params        map[string]string
 	ImageResource ImageResource `yaml:"image_resource"`
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -34,6 +34,10 @@ outputs:
   - name: output-1
   - name: output-2
   - name: output-3
+caches:
+  - path: cache-1
+  - path: cache-2
+  - path: cache-3
 params:
   VAR1: var-1
   VAR2: var-2
@@ -74,6 +78,17 @@ params:
 				{Name: "input-1"},
 				{Name: "input-2"},
 				{Name: "input-3"},
+			}))
+		})
+
+		It("parses the task config for the caches", func() {
+			config, err := parser.Parse(configFilePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(config.Caches).To(Equal([]piper.VolumeMount{
+				{Path: "cache-1"},
+				{Path: "cache-2"},
+				{Path: "cache-3"},
 			}))
 		})
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Parser", func() {
 image: docker:///some-docker-image
 run:
   path: /path/to/run/command
+  args: ['-arg1', '-arg2']
 inputs:
   - name: input-1
   - name: input-2
@@ -62,6 +63,7 @@ params:
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(config.Run.Path).To(Equal("/path/to/run/command"))
+			Expect(config.Run.Args).To(Equal([]string{"-arg1", "-arg2"}))
 		})
 
 		It("parses the task config for the inputs", func() {

--- a/piper/main.go
+++ b/piper/main.go
@@ -94,7 +94,10 @@ func main() {
 		Stderr:  os.Stderr,
 	}
 
-	err = dockerClient.Run(taskConfig.Run.Path, dockerRepo, envVars, volumeMounts, privileged, dryRun, rm)
+	command := []string{taskConfig.Run.Path}
+	command = append(command, taskConfig.Run.Args...)
+
+	err = dockerClient.Run(command, dockerRepo, envVars, volumeMounts, privileged, dryRun, rm)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/piper/main.go
+++ b/piper/main.go
@@ -56,6 +56,7 @@ func main() {
 	var resources []piper.VolumeMount
 	resources = append(resources, taskConfig.Inputs...)
 	resources = append(resources, taskConfig.Outputs...)
+	resources = append(resources, taskConfig.Caches...)
 
 	volumeMounts, err := piper.VolumeMountBuilder{}.Build(resources, inputPairs, outputPairs)
 	if err != nil {

--- a/volume_mount_builder.go
+++ b/volume_mount_builder.go
@@ -34,6 +34,16 @@ func (b VolumeMountBuilder) Build(resources []VolumeMount, inputs, outputs []str
 	var mounts []DockerVolumeMount
 	var missingResources []string
 	for _, resource := range resources {
+		if resource.Name == "" && resource.Path != "" {
+			mountPoint := filepath.Join(VolumeMountPoint, resource.Path)
+
+			mounts = append(mounts, DockerVolumeMount{
+				LocalPath:  "/tmp",
+				RemotePath: filepath.Clean(mountPoint),
+			})
+			continue
+		}
+
 		resourceLocation, ok := pairsMap[resource.Name]
 		if !ok {
 			if !resource.Optional {

--- a/volume_mount_builder_test.go
+++ b/volume_mount_builder_test.go
@@ -17,6 +17,7 @@ var _ = Describe("VolumeMountBuilder", func() {
 				piper.VolumeMount{Name: "input-2", Optional: true},
 				piper.VolumeMount{Name: "output-1"},
 				piper.VolumeMount{Name: "output-2"},
+				piper.VolumeMount{Path: "cache-1"},
 			}, []string{
 				"input-1=/some/path-1",
 				"input-2=/some/path-2",
@@ -25,7 +26,7 @@ var _ = Describe("VolumeMountBuilder", func() {
 				"output-2=/some/path-4",
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(mounts).To(Equal([]piper.DockerVolumeMount{
+			Expect(mounts[0:4]).To(Equal([]piper.DockerVolumeMount{
 				{
 					LocalPath:  "/some/path-1",
 					RemotePath: "/tmp/build/input-1",
@@ -43,6 +44,8 @@ var _ = Describe("VolumeMountBuilder", func() {
 					RemotePath: "/tmp/build/output-2",
 				},
 			}))
+			Expect(mounts[4].LocalPath).To(Equal("/tmp"))
+			Expect(mounts[4].RemotePath).To(Equal("/tmp/build/cache-1"))
 		})
 
 		It("honors the path given in the VolumeMount", func() {


### PR DESCRIPTION
1. pass `args` to the docker run command.
2. default `caches` path to the `/tmp` directory. Originally tried to use `TmpDir` from golang, but the mount point generated could not be used by `docker run` as a volume mount.