### PR TITLE
Fix long-form --tty flag

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -78,7 +78,7 @@ func (c DockerClient) Run(
 		c.Command.Args = append(c.Command.Args, mount.String())
 	}
 
-	c.Command.Args = append(c.Command.Args, "-tty")
+	c.Command.Args = append(c.Command.Args, "--tty")
 	c.Command.Args = append(c.Command.Args, image)
 	c.Command.Args = append(c.Command.Args, command...)
 

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -86,7 +86,7 @@ var _ = Describe("DockerClient", func() {
 				"--env=VAR2=var-2",
 				"--volume=/some/local/path-1:/some/remote/path-1",
 				"--volume=/some/local/path-2:/some/remote/path-2",
-				"-tty",
+				"--tty",
 				"my-image",
 				"my-task.sh",
 				"-my-arg1",
@@ -106,7 +106,7 @@ var _ = Describe("DockerClient", func() {
 				"run",
 				"--workdir=/tmp/build",
 				"--privileged",
-				"-tty",
+				"--tty",
 				"my-image",
 				"my-task.sh",
 			}
@@ -124,7 +124,7 @@ var _ = Describe("DockerClient", func() {
 				"run",
 				"--workdir=/tmp/build",
 				"--rm",
-				"-tty",
+				"--tty",
 				"my-image",
 				"my-task.sh",
 			}
@@ -143,7 +143,7 @@ var _ = Describe("DockerClient", func() {
 				"run",
 				"--workdir=/tmp/build",
 				"--privileged",
-				"-tty",
+				"--tty",
 				"my-image",
 				"my-task.sh",
 			}

--- a/piper/main_test.go
+++ b/piper/main_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(dockerInvocations)), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image", pathToDocker),
-			fmt.Sprintf("%s run --workdir=/tmp/build --env=VAR1=var-1 --volume=/tmp/local-1:/tmp/build/input-1 --volume=/tmp/local-2:/tmp/build/output-1 -tty my-image my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --env=VAR1=var-1 --volume=/tmp/local-1:/tmp/build/input-1 --volume=/tmp/local-2:/tmp/build/output-1 --tty my-image my-task.sh", pathToDocker),
 		}))
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(dockerInvocations)), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image:my-tag", pathToDocker),
-			fmt.Sprintf("%s run --workdir=/tmp/build --env=VAR1=var-1 --volume=/tmp/local-1:/tmp/build/input-1 --volume=/tmp/local-2:/tmp/build/output-1 -tty my-image:my-tag my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --env=VAR1=var-1 --volume=/tmp/local-1:/tmp/build/input-1 --volume=/tmp/local-2:/tmp/build/output-1 --tty my-image:my-tag my-task.sh", pathToDocker),
 		}))
 	})
 
@@ -86,7 +86,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(dockerInvocations)), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image:x.y", pathToDocker),
-			fmt.Sprintf("%s run --workdir=/tmp/build --privileged --volume=/tmp/local-1:/tmp/build/some/path/input --volume=/tmp/local-2:/tmp/build/some/path/output -tty my-image:x.y my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --privileged --volume=/tmp/local-1:/tmp/build/some/path/input --volume=/tmp/local-2:/tmp/build/some/path/output --tty my-image:x.y my-task.sh", pathToDocker),
 		}))
 	})
 
@@ -105,7 +105,7 @@ var _ = Describe("Piper", func() {
 		dockerCommands := strings.Split(strings.TrimSpace(string(session.Out.Contents())), "\n")
 		Expect(dockerCommands).To(Equal([]string{
 			fmt.Sprintf("%s pull my-image:x.y", pathToDocker),
-			fmt.Sprintf("%s run --workdir=/tmp/build --privileged --volume=/tmp/local-1:/tmp/build/some/path/input --volume=/tmp/local-2:/tmp/build/some/path/output -tty my-image:x.y my-task.sh", pathToDocker),
+			fmt.Sprintf("%s run --workdir=/tmp/build --privileged --volume=/tmp/local-1:/tmp/build/some/path/input --volume=/tmp/local-2:/tmp/build/some/path/output --tty my-image:x.y my-task.sh", pathToDocker),
 		}))
 		_, err = os.Stat(dockerconfig.InvocationsPath)
 		Expect(os.IsNotExist(err)).To(BeTrue())


### PR DESCRIPTION
We were seeing an error about an unrecognized flag -y. This is because
docker interprets -tty as an abbreviation of -t -t -y.

Co-authored-by: Oliver Albertini <oalbertini@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>