### PR TITLE
Expand `~` in input and ouput mappings

### DIFF
--- a/volume_mount_builder_test.go
+++ b/volume_mount_builder_test.go
@@ -48,6 +48,20 @@ var _ = Describe("VolumeMountBuilder", func() {
 			Expect(mounts[4].RemotePath).To(Equal("/tmp/build/cache-1"))
 		})
 
+		It("expands '~' in paths", func() {
+			mounts, err := builder.Build([]piper.VolumeMount{
+				piper.VolumeMount{Name: "input-1"},
+				piper.VolumeMount{Name: "output-1"},
+			}, []string{
+				"input-1=~/some/path-1",
+			}, []string{
+				"output-1=~/some/path-2",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mounts[0].LocalPath).ShouldNot(ContainSubstring("~"))
+			Expect(mounts[1].LocalPath).ShouldNot(ContainSubstring("~"))
+		})
+
 		It("honors the path given in the VolumeMount", func() {
 			mounts, err := builder.Build([]piper.VolumeMount{
 				piper.VolumeMount{Name: "input-1", Path: "some/path/to/input"},


### PR DESCRIPTION
Bash expansion of `~` to a users homer directory can be a little finicky. For
example:

```sh
./piper -c task.yml -i my_app=~/workspace/my-app
```

will work, while

```sh
./piper -c task.yml -i my-app=~/workspace/my-app
```

According to [this StackOverflow answer][0], the shell expansion works in the
first example because `my_app=~/workspace/my-app` resembles a variable
assignment. In the second example, `my-app=~/workspace/my-app`  does not
resemble a valid variable assignment.

The problem is a little trickier in shells like `zsh` or `sh` (see [this SO
answer][1] for more details). To be clear, this is not an issue with `piper`
but the semantics of shell expansion. The proposed feature is purely a
convenience when using `piper` interactively (as opposed to inside a shell
script).

[0]: https://stackoverflow.com/a/15504442
[1]: https://unix.stackexchange.com/a/373532